### PR TITLE
Default JDK and configurable test skippage

### DIFF
--- a/events/pull_request-event-action/action.yml
+++ b/events/pull_request-event-action/action.yml
@@ -12,7 +12,11 @@ inputs:
   JDK_VERSION:
     required: false
     description: "The version of the JDK to setup."
-    default: 11
+    default: 17
+  IGNORE_TEST_FAILURES:
+    required: false
+    description: "Allow tests to fail."
+    default: false
 
 runs:
   using: "composite"
@@ -28,5 +32,4 @@ runs:
       with:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
-        IGNORE_TEST_FAILURES: true
-
+        IGNORE_TEST_FAILURES: ${{ inputs.IGNORE_TEST_FAILURES }}

--- a/events/push-event-action/action.yml
+++ b/events/push-event-action/action.yml
@@ -25,7 +25,11 @@ inputs:
   JDK_VERSION:
     required: false
     description: "The version of the JDK to setup."
-    default: 11
+    default: 17
+  IGNORE_TEST_FAILURES:
+    required: false
+    description: "Allow tests to fail."
+    default: false
 
 runs:
   using: "composite"
@@ -44,7 +48,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
-        IGNORE_TEST_FAILURES: true
+        IGNORE_TEST_FAILURES: ${{ inputs.IGNORE_TEST_FAILURES }}
 
     - id: get-project-version
       uses: ./aerius-github-actions/common/get-maven-project-version

--- a/events/release-event-action/action.yml
+++ b/events/release-event-action/action.yml
@@ -26,10 +26,6 @@ inputs:
      required: false
      description: "The version of the JDK to setup."
      default: 17
-  IGNORE_TEST_FAILURES:
-    required: false
-    description: "Allow tests to fail."
-    default: false
 
 runs:
   using: "composite"
@@ -48,7 +44,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
-        IGNORE_TEST_FAILURES: ${{ inputs.IGNORE_TEST_FAILURES }}
+        IGNORE_TEST_FAILURES: false
 
     - uses: ./aerius-github-actions/common/publish-maven-artifacts
       with:

--- a/events/release-event-action/action.yml
+++ b/events/release-event-action/action.yml
@@ -25,7 +25,11 @@ inputs:
    JDK_VERSION:
      required: false
      description: "The version of the JDK to setup."
-     default: 11
+     default: 17
+  IGNORE_TEST_FAILURES:
+    required: false
+    description: "Allow tests to fail."
+    default: false
 
 runs:
   using: "composite"
@@ -44,7 +48,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
-        IGNORE_TEST_FAILURES: false
+        IGNORE_TEST_FAILURES: ${{ inputs.IGNORE_TEST_FAILURES }}
 
     - uses: ./aerius-github-actions/common/publish-maven-artifacts
       with:

--- a/extras/docker-build-or-publish-based-on-maven-project-version-action/action.yml
+++ b/extras/docker-build-or-publish-based-on-maven-project-version-action/action.yml
@@ -33,7 +33,7 @@ inputs:
   JDK_VERSION:
     required: false
     description: "The version of the JDK to setup. Because this is used only to determine Maven project version it doesn't have to match the JDK needed to build to projects themselves."
-    default: 11
+    default: 17
 
 runs:
   using: "composite"

--- a/extras/docker-publish-action/action.yml
+++ b/extras/docker-publish-action/action.yml
@@ -33,7 +33,7 @@ inputs:
   JDK_VERSION:
     required: false
     description: "The version of the JDK to setup."
-    default: 11
+    default: 17
 
 runs:
   using: "composite"


### PR DESCRIPTION
- Switched from 11 to 17 as default JDK
- Allowing test failure behaviour to be configurable, and switched to default no ignoring.