### PR TITLE
On push event, ignore dependabot branches

### DIFF
--- a/events/push-event-action/action.yml
+++ b/events/push-event-action/action.yml
@@ -56,7 +56,8 @@ runs:
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
 
     # Artifacts should only be published on pushes with a SNAPSHOT version
-    - if: endsWith(steps.get-project-version.outputs.version, '-SNAPSHOT')
+    # We will also ignore dependendabot branches - as they don't originate from a fork
+    - if: ${{ !startswith(github.ref_name, 'dependabot/') && endsWith(steps.get-project-version.outputs.version, '-SNAPSHOT') }}
       uses: ./aerius-github-actions/common/publish-maven-artifacts
       with:
         NEXUS_USERNAME: ${{ inputs.NEXUS_USERNAME }}


### PR DESCRIPTION
Dependabot is the only exception, making branches for it's PRs on the main repository. This will auto push artifacts as well if we want to mix version changes in there as well.