### PR TITLE
[extras/docker-*-action] Add support to build/publish multiple platforms

### DIFF
--- a/extras/docker-build-action/action.yml
+++ b/extras/docker-build-action/action.yml
@@ -16,6 +16,10 @@ inputs:
     required: false
     description: "The location of the Dockerfile inside the Docker work directory."
     default: "Dockerfile"
+  DOCKER_BUILD_PLATFORMS:
+    required: false
+    description: "The platforms to build for, e.g.: linux/amd64,linux/arm64"
+    default: ""
 
 runs:
   using: "composite"
@@ -24,11 +28,20 @@ runs:
       with:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
+    - if: inputs.DOCKER_BUILD_PLATFORMS != ''
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - if: inputs.DOCKER_BUILD_PLATFORMS != ''
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Build Docker image
       uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ inputs.DOCKER_IMAGE_NAME }}
         workdir: ${{ inputs.DOCKER_WORK_DIRECTORY }}/
         dockerfile: ${{ inputs.DOCKERFILE_LOCATION }}
+        platforms: ${{ inputs.DOCKER_BUILD_PLATFORMS }}
         no_push: true
 

--- a/extras/docker-build-or-publish-based-on-maven-project-version-action/action.yml
+++ b/extras/docker-build-or-publish-based-on-maven-project-version-action/action.yml
@@ -26,6 +26,10 @@ inputs:
     required: false
     description: "The location of the Dockerfile inside the Docker work directory."
     default: "Dockerfile"
+  DOCKER_BUILD_PLATFORMS:
+    required: false
+    description: "The platforms to build for, e.g.: linux/amd64,linux/arm64"
+    default: ""
   ROOT_POM_DIRECTORY:
     required: false
     description: "The directory where the root POM can be found."
@@ -48,6 +52,14 @@ runs:
       with:
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
 
+    - if: inputs.DOCKER_BUILD_PLATFORMS != ''
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - if: inputs.DOCKER_BUILD_PLATFORMS != ''
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     # Images should only be published if a release is made, otherwise only on pushes with a SNAPSHOT version
     - if: github.event_name == 'release' || endsWith(steps.get-project-version.outputs.VERSION, '-SNAPSHOT')
       name: Publish Docker image
@@ -59,6 +71,7 @@ runs:
         registry: ${{ inputs.DOCKER_REGISTRY }}
         workdir: ${{ inputs.DOCKER_WORK_DIRECTORY }}/
         dockerfile: ${{ inputs.DOCKERFILE_LOCATION }}
+        platforms: ${{ inputs.DOCKER_BUILD_PLATFORMS }}
         tag_semver: true
 
     # Images should only be build if it's not a release, otherwise only on pushes with a non SNAPSHOT version
@@ -69,5 +82,6 @@ runs:
         name: ${{ inputs.DOCKER_IMAGE_NAME }}
         workdir: ${{ inputs.DOCKER_WORK_DIRECTORY }}/
         dockerfile: ${{ inputs.DOCKERFILE_LOCATION }}
+        platforms: ${{ inputs.DOCKER_BUILD_PLATFORMS }}
         no_push: true
 

--- a/extras/docker-publish-action/action.yml
+++ b/extras/docker-publish-action/action.yml
@@ -26,6 +26,10 @@ inputs:
     required: false
     description: "The location of the Dockerfile inside the Docker work directory."
     default: "Dockerfile"
+  DOCKER_BUILD_PLATFORMS:
+    required: false
+    description: "The platforms to build for, e.g.: linux/amd64,linux/arm64"
+    default: ""
   ROOT_POM_DIRECTORY:
     required: false
     description: "The directory where the root POM can be found."
@@ -48,6 +52,14 @@ runs:
       with:
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
 
+    - if: inputs.DOCKER_BUILD_PLATFORMS != ''
+      name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - if: inputs.DOCKER_BUILD_PLATFORMS != ''
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     # Artifacts should only be published if a release is made, otherwise only on pushes with a SNAPSHOT version
     - if: github.event_name == 'release' || (github.event_name == 'push' && endsWith(steps.get-project-version.outputs.VERSION, '-SNAPSHOT'))
       name: Publish Docker image
@@ -59,5 +71,6 @@ runs:
         registry: ${{ inputs.DOCKER_REGISTRY }}
         workdir: ${{ inputs.DOCKER_WORK_DIRECTORY }}/
         dockerfile: ${{ inputs.DOCKERFILE_LOCATION }}
+        platforms: ${{ inputs.DOCKER_BUILD_PLATFORMS }}
         tag_semver: true
 


### PR DESCRIPTION
If `platforms` is an empty string, it's the same as not being set (the external step checks whether the var has a non-zero length)