### PR TITLE
[extras/docker-*-action] Remove QEMU action

### DIFF
--- a/extras/docker-build-action/action.yml
+++ b/extras/docker-build-action/action.yml
@@ -29,10 +29,6 @@ runs:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
     - if: inputs.DOCKER_BUILD_PLATFORMS != ''
-      name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - if: inputs.DOCKER_BUILD_PLATFORMS != ''
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 

--- a/extras/docker-build-or-publish-based-on-maven-project-version-action/action.yml
+++ b/extras/docker-build-or-publish-based-on-maven-project-version-action/action.yml
@@ -53,10 +53,6 @@ runs:
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
 
     - if: inputs.DOCKER_BUILD_PLATFORMS != ''
-      name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - if: inputs.DOCKER_BUILD_PLATFORMS != ''
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 

--- a/extras/docker-publish-action/action.yml
+++ b/extras/docker-publish-action/action.yml
@@ -53,10 +53,6 @@ runs:
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
 
     - if: inputs.DOCKER_BUILD_PLATFORMS != ''
-      name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - if: inputs.DOCKER_BUILD_PLATFORMS != ''
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
By default it can already compile ARM64 without needing this. If we need it for some obscure reason, we can re-add it later.