### PR TITLE
Use different profile for build actions

### DIFF
--- a/common/build-and-analyse-using-maven-and-sonar/action.yml
+++ b/common/build-and-analyse-using-maven-and-sonar/action.yml
@@ -11,9 +11,13 @@ inputs:
   IGNORE_TEST_FAILURES:
     required: true
     description: "Whether to ignore test failures."
+  MAVEN_PROFILE:
+    required: true
+    description: "The maven profile(s) to use."
   SONAR_TOKEN:
     required: false
     description: "The token needed to push analyses to Sonar. Will skip this step if not provided."
+
 
 runs:
   using: "composite"
@@ -25,5 +29,5 @@ runs:
       shell: bash
       run: |
         SONAR_TOKEN=${{ inputs.SONAR_TOKEN }}
-        mvn --no-transfer-progress -f ${{ inputs.ROOT_POM_DIRECTORY }}/pom.xml -Dmaven.test.failure.ignore=${{ inputs.IGNORE_TEST_FAILURES }} -P ${SONAR_TOKEN:+sonar,}publish verify ${SONAR_TOKEN:+org.sonarsource.scanner.maven:sonar-maven-plugin::sonar}
+        mvn --no-transfer-progress -f ${{ inputs.ROOT_POM_DIRECTORY }}/pom.xml -Dmaven.test.failure.ignore=${{ inputs.IGNORE_TEST_FAILURES }} -P ${SONAR_TOKEN:+sonar,}${{ inputs.MAVEN_PROFILE }} verify ${SONAR_TOKEN:+org.sonarsource.scanner.maven:sonar-maven-plugin::sonar}
 

--- a/common/build-and-analyse-using-maven-and-sonar/action.yml
+++ b/common/build-and-analyse-using-maven-and-sonar/action.yml
@@ -11,7 +11,7 @@ inputs:
   IGNORE_TEST_FAILURES:
     required: true
     description: "Whether to ignore test failures."
-  MAVEN_PROFILE:
+  MAVEN_BUILD_PROFILE:
     required: true
     description: "The maven profile(s) to use."
   SONAR_TOKEN:
@@ -29,5 +29,5 @@ runs:
       shell: bash
       run: |
         SONAR_TOKEN=${{ inputs.SONAR_TOKEN }}
-        mvn --no-transfer-progress -f ${{ inputs.ROOT_POM_DIRECTORY }}/pom.xml -Dmaven.test.failure.ignore=${{ inputs.IGNORE_TEST_FAILURES }} -P ${SONAR_TOKEN:+sonar,}${{ inputs.MAVEN_PROFILE }} verify ${SONAR_TOKEN:+org.sonarsource.scanner.maven:sonar-maven-plugin::sonar}
+        mvn --no-transfer-progress -f ${{ inputs.ROOT_POM_DIRECTORY }}/pom.xml -Dmaven.test.failure.ignore=${{ inputs.IGNORE_TEST_FAILURES }} -P ${SONAR_TOKEN:+sonar,}${{ inputs.MAVEN_BUILD_PROFILE }} verify ${SONAR_TOKEN:+org.sonarsource.scanner.maven:sonar-maven-plugin::sonar}
 

--- a/common/build-and-analyse-using-maven-and-sonar/action.yml
+++ b/common/build-and-analyse-using-maven-and-sonar/action.yml
@@ -18,7 +18,6 @@ inputs:
     required: false
     description: "The token needed to push analyses to Sonar. Will skip this step if not provided."
 
-
 runs:
   using: "composite"
   steps:

--- a/common/build-using-maven/action.yml
+++ b/common/build-using-maven/action.yml
@@ -11,7 +11,7 @@ inputs:
   IGNORE_TEST_FAILURES:
     required: true
     description: "Whether to ignore test failures."
-  MAVEN_PROFILE:
+  MAVEN_BUILD_PROFILE:
     required: true
     description: "The maven profile(s) to use."
 
@@ -22,5 +22,5 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       shell: bash
-      run: mvn --no-transfer-progress -f ${{ inputs.ROOT_POM_DIRECTORY }}/pom.xml -Dmaven.test.failure.ignore=${{ inputs.IGNORE_TEST_FAILURES }} -P ${{ inputs.MAVEN_PROFILE }} verify
+      run: mvn --no-transfer-progress -f ${{ inputs.ROOT_POM_DIRECTORY }}/pom.xml -Dmaven.test.failure.ignore=${{ inputs.IGNORE_TEST_FAILURES }} -P ${{ inputs.MAVEN_BUILD_PROFILE }} verify
 

--- a/common/build-using-maven/action.yml
+++ b/common/build-using-maven/action.yml
@@ -11,6 +11,9 @@ inputs:
   IGNORE_TEST_FAILURES:
     required: true
     description: "Whether to ignore test failures."
+  MAVEN_PROFILE:
+    required: true
+    description: "The maven profile(s) to use."
 
 runs:
   using: "composite"
@@ -19,5 +22,5 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       shell: bash
-      run: mvn --no-transfer-progress -f ${{ inputs.ROOT_POM_DIRECTORY }}/pom.xml -Dmaven.test.failure.ignore=${{ inputs.IGNORE_TEST_FAILURES }} -P publish verify
+      run: mvn --no-transfer-progress -f ${{ inputs.ROOT_POM_DIRECTORY }}/pom.xml -Dmaven.test.failure.ignore=${{ inputs.IGNORE_TEST_FAILURES }} -P ${{ inputs.MAVEN_PROFILE }} verify
 

--- a/common/publish-maven-artifacts/action.yml
+++ b/common/publish-maven-artifacts/action.yml
@@ -14,6 +14,9 @@ inputs:
   ROOT_POM_DIRECTORY:
     required: true
     description: "The directory where the root POM can be found."
+  MAVEN_PUBLISH_PROFILE:
+    required: true
+    description: "The maven profile(s) to use."
 
 runs:
   using: "composite"
@@ -24,5 +27,5 @@ runs:
         server_id: ${{ inputs.POM_PUBLISH_REPOSITORY_NAME }}
         nexus_username: ${{ inputs.NEXUS_USERNAME }}
         nexus_password: ${{ inputs.NEXUS_PASSWORD }}
-        maven_args: -DskipTests -P publish -f ${{ inputs.ROOT_POM_DIRECTORY }}/pom.xml
+        maven_args: -DskipTests -P ${{ inputs.MAVEN_PUBLISH_PROFILE }} -f ${{ inputs.ROOT_POM_DIRECTORY }}/pom.xml
 

--- a/events/pull_request-event-action/action.yml
+++ b/events/pull_request-event-action/action.yml
@@ -17,9 +17,9 @@ inputs:
     required: false
     description: "Allow tests to fail."
     default: false
-  MAVEN_PROFILE:
+  MAVEN_BUILD_PROFILE:
     required: false
-    description: "The maven profile(s) to use. By default only 'all' will be used."
+    description: "The maven profile(s) to use when building. By default only 'all' will be used."
     default: "all"
 
 runs:
@@ -37,4 +37,4 @@ runs:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
         IGNORE_TEST_FAILURES: ${{ inputs.IGNORE_TEST_FAILURES }}
-        MAVEN_PROFILE: ${{ inputs.MAVEN_PROFILE }}
+        MAVEN_BUILD_PROFILE: ${{ inputs.MAVEN_BUILD_PROFILE }}

--- a/events/pull_request-event-action/action.yml
+++ b/events/pull_request-event-action/action.yml
@@ -17,6 +17,10 @@ inputs:
     required: false
     description: "Allow tests to fail."
     default: false
+  MAVEN_PROFILE:
+    required: false
+    description: "The maven profile(s) to use. By default only 'all' will be used."
+    default: "all"
 
 runs:
   using: "composite"
@@ -33,3 +37,4 @@ runs:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
         IGNORE_TEST_FAILURES: ${{ inputs.IGNORE_TEST_FAILURES }}
+        MAVEN_PROFILE: ${{ inputs.MAVEN_PROFILE }}

--- a/events/push-event-action/action.yml
+++ b/events/push-event-action/action.yml
@@ -30,6 +30,10 @@ inputs:
     required: false
     description: "Allow tests to fail."
     default: false
+  MAVEN_PROFILE:
+    required: false
+    description: "The maven profile(s) to use. By default only 'all' will be used."
+    default: "all"
 
 runs:
   using: "composite"
@@ -49,6 +53,7 @@ runs:
         SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
         IGNORE_TEST_FAILURES: ${{ inputs.IGNORE_TEST_FAILURES }}
+        MAVEN_PROFILE: ${{ inputs.MAVEN_PROFILE }}
 
     - id: get-project-version
       uses: ./aerius-github-actions/common/get-maven-project-version

--- a/events/push-event-action/action.yml
+++ b/events/push-event-action/action.yml
@@ -30,9 +30,9 @@ inputs:
     required: false
     description: "Allow tests to fail."
     default: false
-  MAVEN_PROFILE:
+  MAVEN_BUILD_PROFILE:
     required: false
-    description: "The maven profile(s) to use. By default only 'all' will be used."
+    description: "The maven profile(s) to use when building. By default only 'all' will be used."
     default: "all"
 
 runs:
@@ -53,7 +53,7 @@ runs:
         SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
         IGNORE_TEST_FAILURES: ${{ inputs.IGNORE_TEST_FAILURES }}
-        MAVEN_PROFILE: ${{ inputs.MAVEN_PROFILE }}
+        MAVEN_BUILD_PROFILE: ${{ inputs.MAVEN_BUILD_PROFILE }}
 
     - id: get-project-version
       uses: ./aerius-github-actions/common/get-maven-project-version

--- a/events/release-event-action/action.yml
+++ b/events/release-event-action/action.yml
@@ -2,30 +2,34 @@ name: "release event action"
 description: "On release event build and publish AERIUS Java project, including running the unittests / a Sonar analysis"
 
 inputs:
-   GITHUB_TOKEN:
-     required: true
-     description: "Just pass the secrets.GITHUB_TOKEN to this action as input."
-   SONAR_TOKEN:
-     required: false
-     description: "The token needed to push analyses to Sonar. If not set this will be skipped."
-   NEXUS_USERNAME:
-     required: true
-     description: "The Nexus username needed to publish packages."
-   NEXUS_PASSWORD:
-     required: true
-     description: "The Nexus password needed to publish packages."
-   POM_PUBLISH_REPOSITORY_NAME:
-     required: false
-     description: "The repository as specified in the root POM to publish to."
-     default: "aerius-nexus"
-   ROOT_POM_DIRECTORY:
-     required: false
-     description: "The directory where the root POM can be found."
-     default: "repo"
-   JDK_VERSION:
-     required: false
-     description: "The version of the JDK to setup."
-     default: 21
+  GITHUB_TOKEN:
+    required: true
+    description: "Just pass the secrets.GITHUB_TOKEN to this action as input."
+  SONAR_TOKEN:
+    required: false
+    description: "The token needed to push analyses to Sonar. If not set this will be skipped."
+  NEXUS_USERNAME:
+    required: true
+    description: "The Nexus username needed to publish packages."
+  NEXUS_PASSWORD:
+    required: true
+    description: "The Nexus password needed to publish packages."
+  POM_PUBLISH_REPOSITORY_NAME:
+    required: false
+    description: "The repository as specified in the root POM to publish to."
+    default: "aerius-nexus"
+  ROOT_POM_DIRECTORY:
+    required: false
+    description: "The directory where the root POM can be found."
+    default: "repo"
+  JDK_VERSION:
+    required: false
+    description: "The version of the JDK to setup."
+    default: 21
+  MAVEN_PROFILE:
+    required: false
+    description: "The maven profile(s) to use. By default only 'all' will be used. For the publish part, the 'publish' profile will be used."
+    default: "all"
 
 runs:
   using: "composite"
@@ -44,6 +48,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
+        MAVEN_PROFILE: ${{ inputs.MAVEN_PROFILE }}
         IGNORE_TEST_FAILURES: false
 
     - uses: ./aerius-github-actions/common/publish-maven-artifacts

--- a/events/release-event-action/action.yml
+++ b/events/release-event-action/action.yml
@@ -26,10 +26,14 @@ inputs:
     required: false
     description: "The version of the JDK to setup."
     default: 21
-  MAVEN_PROFILE:
+  MAVEN_BUILD_PROFILE:
     required: false
-    description: "The maven profile(s) to use. By default only 'all' will be used. For the publish part, the 'publish' profile will be used."
+    description: "The maven profile(s) to use when building. By default only 'all' will be used."
     default: "all"
+  MAVEN_PUBLISH_PROFILE:
+    required: false
+    description: "The maven profile(s) to use when publishing to Nexus. By default only 'publish' will be used."
+    default: "publish"
 
 runs:
   using: "composite"
@@ -48,7 +52,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ inputs.SONAR_TOKEN }}
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
-        MAVEN_PROFILE: ${{ inputs.MAVEN_PROFILE }}
+        MAVEN_BUILD_PROFILE: ${{ inputs.MAVEN_BUILD_PROFILE }}
         IGNORE_TEST_FAILURES: false
 
     - uses: ./aerius-github-actions/common/publish-maven-artifacts
@@ -57,4 +61,5 @@ runs:
         NEXUS_PASSWORD: ${{ inputs.NEXUS_PASSWORD }}
         POM_PUBLISH_REPOSITORY_NAME: ${{ inputs.POM_PUBLISH_REPOSITORY_NAME }}
         ROOT_POM_DIRECTORY: ${{ inputs.ROOT_POM_DIRECTORY }}
+        MAVEN_PUBLISH_PROFILE: ${{ inputs.MAVEN_PUBLISH_PROFILE }}
 


### PR DESCRIPTION
By using a different profile than publish, all modules should be build/tested. The `all` profile, if exists, is expected to contain all the modules. If the profile does not exist, it is ignored by maven and the default profiles should kick in (this was already the case for IMAER-java as an example, which did not specify the `publish` profile).

I would expect this to be safe backwards-compatibility wise, but not sure how to test this without actually merging this either...